### PR TITLE
Adds info about new dependency on cerializer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The following are required:
   * A C++ compiler
   * Cython
   * pkg-config
+  * cerealizer
   * The OpenGL, GLU, GLib, SDL, SDL_mixer, libogg, libvorbisfile,
     libtheora, libsoundtouch, and libswscale (part of ffmpeg) development headers
 
@@ -246,7 +247,7 @@ following packages: `python-pygame`, `python-opengl`, `python-numpy`,
 `python-imaging`, `python-dev`, `build-essential`, `cython`, `pkg-config`,
 `libgl1-mesa-dev`, `libglu1-mesa-dev`, `libglib2.0-dev`, `libsdl1.2-dev`,
 `libsdl-mixer1.2-dev`, `libogg-dev`, `libvorbisfile-dev`, `libtheora-dev`,
-`libswscale-dev`, `libsoundtouch-dev`, and if you want translations, `gettext`.
+`libswscale-dev`, `libsoundtouch-dev`, `python-cerealizer`, and if you want translations, `gettext`.
 
 Some packages can be troublesome, so we have notes below about certain
 packages.


### PR DESCRIPTION
The new activity made me curious. After pulling the new code I noticed the game wouldn't run as a dependency was missing.

This simple addition to the README.md only covers the case of GNU/Linux users but is a step in the right direction.

(I would have pushed it myself but it seems I am not (and never was?) a member of the project on GitHub).