### PR TITLE
Futurize fofix.core.Language

### DIFF
--- a/fofix/core/Language.py
+++ b/fofix/core/Language.py
@@ -19,21 +19,25 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,        #
 # MA  02110-1301, USA.                                              #
 #####################################################################
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import gettext
-import os
 import glob
+import os
 
 from fretwork import log
 
 from fofix.core import Version
 from fofix.core import Config
 
-Config.define("game", "language", str, "")
 
 def getAvailableLanguages():
     return [os.path.basename(l).capitalize().replace(".mo", "").replace("_", " ") for l in glob.glob(os.path.join(Version.dataPath(), "translations", "*.mo"))]
 
+
+Config.define("game", "language", str, "")
 
 language = Config.load(Version.PROGRAM_UNIXSTYLE_NAME + ".ini").get("game", "language")
 catalog = gettext.NullTranslations()
@@ -53,4 +57,4 @@ _ = catalog.ugettext
 langOptions = {"": "English"}
 for lang in getAvailableLanguages():
     langOptions[lang] = _(lang)
-Config.define("game", "language", str, "", _("Language"), langOptions, tipText = _("Change the game language!"))
+Config.define("game", "language", str, "", _("Language"), langOptions, tipText=_("Change the game language!"))

--- a/fofix/core/Language.py
+++ b/fofix/core/Language.py
@@ -25,7 +25,6 @@ import os
 import glob
 
 from fretwork import log
-from fretwork.unicode import unicodify
 
 from fofix.core import Version
 from fofix.core import Config
@@ -35,23 +34,20 @@ Config.define("game", "language", str, "")
 def getAvailableLanguages():
     return [os.path.basename(l).capitalize().replace(".mo", "").replace("_", " ") for l in glob.glob(os.path.join(Version.dataPath(), "translations", "*.mo"))]
 
-def dummyTranslator(string):
-    return unicodify(string)
 
 language = Config.load(Version.PROGRAM_UNIXSTYLE_NAME + ".ini").get("game", "language")
-_ = dummyTranslator
+catalog = gettext.NullTranslations()
 
 if language:
     try:
         trFile = os.path.join(Version.dataPath(), "translations", "%s.mo" % language.lower().replace(" ", "_"))
         catalog = gettext.GNUTranslations(open(trFile, "rb"))
-        def translate(m):
-            return catalog.ugettext(m)
-        _ = translate
     except Exception as x:
         log.warn("Unable to select language '%s': %s" % (language, x))
         language = None
         Config.set("game", "language", "")
+
+_ = catalog.ugettext
 
 # Define the config key again now that we have some options for it
 langOptions = {"": "English"}


### PR DESCRIPTION
Futurize `fofix.core.Language` as a small step toward #110.

Also replace `fretwork.unicodify` with `gettext.NullTranslations` as converting to Python 3 will otherwise remove the need for `unicodify` and `NullTranslations` is intended as the "dummy" `_`.