### PR TITLE
Doc: comment the HTML static path as it does not exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /bin/
 /build/
 /dist/
+/doc/build/
 /include/
 /gstreamer/
 /lib/

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -98,7 +98,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
This folder does not exists.
Ignore the build dir too.