### PR TITLE
Install Cerealizer in non binary mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,6 @@ install:
     - pip install pytest
     - pip install cython
     - pip install -r requirements.txt
-    # hack: cerealizer
-    - export PY_PACKAGES=`pip --version | cut -d' ' -f4`
-    - wget https://bitbucket.org/jibalamy/cerealizer/raw/ffbb9283c507c2bb7191bb413722a316e9c0718b/__init__.py2 -O $PY_PACKAGES/cerealizer/__init__.py2
     # build ext
     - python setup.py build_ext --inplace --force
 

--- a/README.md
+++ b/README.md
@@ -45,16 +45,6 @@ OS-specific dependencies:
     - python's developpment headers
     - and: `GLU`, `GLib`, `SDL`, `SDL_mixer`, `libogg`, `libvorbisfile`, `libtheora`, `libsoundtouch`, `libswscale` (part of `ffmpeg`) development headers
 
-    About `cerealizer`, you need to reinstall it. You can run those commands for
-    example:
-
-        pip download cerealizer
-        tar jxf Cerealizer*.tar.bz2 -C /tmp/
-        cd /tmp/Cerealizer-*
-        pip install --upgrade .
-        cd -
-        rm -r /tmp/Cerealizer-* Cerealizer-*
-
 
 ### Native modules
 

--- a/doc/source/quickstart/installation.rst
+++ b/doc/source/quickstart/installation.rst
@@ -19,7 +19,7 @@ From sources
     - OS specific dependencies:
         - `Windows`_
         - `Unix`_
-    - Python dependencies: ``pip install -r requirements.txt`` (see the `Cerealizer package`_ part too!)
+    - Python dependencies: ``pip install -r requirements.txt``
     - optional dependencies:
         - ``pyopengl-accelerate``: this will make PyOpenGL go a good bit faster
         - ``pyaudio``: this provides support for microphone input, which is required for vocal play
@@ -27,6 +27,12 @@ From sources
 - compile native modules::
 
     python setup.py build_ext --inplace --force
+
+
+.. note::
+
+    Due to a bug in the builder, the `cerealizer` is installed in non binary
+    mode.
 
 
 Windows
@@ -48,19 +54,4 @@ Install the following dependencies:
     - ``ffmpeg``
     - ``pkg-config``
     - python's developpment headers
-    - and: ``GLU``, ``GLib``, ``SDL``, ``SDL_mixer``, ``libogg``, ``libvorbisfile``, ``libtheora``, ``libsoundtouch``, ``libswscale`` (part of ``ffmpeg``) development headers
-
-
-`Cerealizer` package
-++++++++++++++++++++
-
-Due to a bug in the builder, the `cerealizer` package should be reinstalled in *Unix* environments. You have 2 solutions:
-    - by installing it from your package manager
-    - by installing it manually::
-
-        pip download cerealizer
-        tar jxf Cerealizer*.tar.bz2 -C /tmp/
-        cd /tmp/Cerealizer-*
-        pip install --upgrade .
-        cd -
-        rm -r /tmp/Cerealizer-* Cerealizer-*
+    - and: ``GLU``, ``GLib``, ``SDL``, ``SDL_mixer``, ``libogg``, ``libvorbisfile``, ``libtheora``, ``libsoundtouch``, ``libswscale`` (part of ``ffmpeg``) development headers.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cerealizer==0.8.1
+Cerealizer==0.8.1 --no-binary Cerealizer
 Cython==0.27.3
 numpy==1.13.3
 olefile==0.44


### PR DESCRIPTION
This way, Cerealizer will be installed properly and hacks can be removed.