### PR TITLE
Update the Cerealizer dependency to 0.8.2

### DIFF
--- a/doc/source/quickstart/installation.rst
+++ b/doc/source/quickstart/installation.rst
@@ -29,12 +29,6 @@ From sources
     python setup.py build_ext --inplace --force
 
 
-.. note::
-
-    Due to a bug in the builder, the `cerealizer` is installed in non binary
-    mode.
-
-
 Windows
 +++++++
 **Only 32 bit Python is supported**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cerealizer==0.8.1 --no-binary Cerealizer
+Cerealizer==0.8.2
 Cython==0.27.3
 numpy==1.13.3
 olefile==0.44


### PR DESCRIPTION
This version fixes its installation bugs: it is not necessary to install it in no-binary mode anymore.
Remove the note about Cerealizer in the installation doc.