### PR TITLE
Use Pillow version number

### DIFF
--- a/fofix/core/GameEngine.py
+++ b/fofix/core/GameEngine.py
@@ -167,7 +167,7 @@ class GameEngine(object):
         log.debug("Pygame version: " + str(pygame.version.ver) )
         log.debug("PyOpenGL version: " + OpenGL.__version__)
         log.debug("Numpy version: " + np.__version__)
-        log.debug("PIL version: " + Image.VERSION)
+        log.debug("PIL version: " + Image.__version__)
         log.debug("sys.argv: " + repr(sys.argv))
         log.debug("os.name: " + os.name)
         log.debug("sys.platform: " + sys.platform)


### PR DESCRIPTION
Image.VERSION always reports 1.1.7, it is deprecated since version
5.2.0 (see https://github.com/python-pillow/Pillow/pull/3090), and
removed from version 6.0.0. The recommended way to access the version
of Pillow is `Image.__version__`.