### PR TITLE
Travis: use Trusty as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
     - 2.7
+dist: trusty
 
 matrix:
     include:


### PR DESCRIPTION
Even though Trusty is EOL, it is still useful for tests requiring OpenGL.
This is the first step in the migration to Xenial.
Ref #193