### PR TITLE
Compile translations before launching the game

### DIFF
--- a/FoFiX.py
+++ b/FoFiX.py
@@ -112,11 +112,22 @@ if __name__ == '__main__':
     if not args['gl_error_check']:
         disable_gl_checks()
 
-    # Imports
-    from fofix.core.Language import _
-    from fofix.game.Main import Main
+    # setup the logfile
+    # File object representing the logfile
+    if is_macos:
+        # Under MacOS X, put the logs in ~/Library/Logs
+        logfile = os.path.expanduser('~/Library/Logs/%s.log' % Version.PROGRAM_UNIXSTYLE_NAME)
+    else:
+        # Unix: ~/.fofix/
+        logfile = VFS.resolveWrite('/userdata/%s.log' % Version.PROGRAM_UNIXSTYLE_NAME)
 
+    log.configure(logfile)
+    logger = logging.getLogger(__name__)
+
+    # Imports
     import fretwork
+    from fofix.game.Main import Main
+    from fofix.core.Language import _
 
     # This prevents the following message being displayed on macOS:
     # ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to *path*
@@ -130,18 +141,6 @@ if __name__ == '__main__':
     # from source on Windows so we pick them up when those bits are imported.
     if is_windows and not hasattr(sys, 'frozen'):
         os.environ['PATH'] = os.path.abspath(os.path.join('.', 'win32', 'deps', 'bin')) + os.pathsep + os.environ['PATH']
-
-    # setup the logfile
-    # File object representing the logfile
-    if is_macos:
-        # Under MacOS X, put the logs in ~/Library/Logs
-        logfile = os.path.expanduser('~/Library/Logs/%s.log' % Version.PROGRAM_UNIXSTYLE_NAME)
-    else:
-        # Unix: ~/.fofix/
-        logfile = VFS.resolveWrite('/userdata/%s.log' % Version.PROGRAM_UNIXSTYLE_NAME)
-
-    log.configure(logfile)
-    logger = logging.getLogger(__name__)
 
     fretworkRequired = (0, 4, 0)
     reqVerStr = '.'.join([str(i) for i in fretworkRequired])

--- a/FoFiX.py
+++ b/FoFiX.py
@@ -94,11 +94,7 @@ if not args['gl_error_check']:
 
 from fofix.core import Version
 from fofix.core import VFS
-from fofix.core.VideoPlayer import VideoLayer, VideoPlayerError
-from fofix.core.GameEngine import GameEngine
-from fofix.game.MainMenu import MainMenu
 from fofix.core.Language import _
-from fofix.core import Config
 from fofix.game.Main import Main
 
 import fretwork

--- a/FoFiX.py
+++ b/FoFiX.py
@@ -41,6 +41,22 @@ import subprocess
 import sys
 import traceback
 
+# PIL doesn't init correctly when inside py2exe, so here we kick it in butt.
+# Web search results all point to this solution:
+# http://www.py2exe.org/index.cgi/py2exeAndPIL
+import PIL.Image
+import PIL.BmpImagePlugin
+import PIL.GifImagePlugin
+import PIL.JpegImagePlugin
+import PIL.MpoImagePlugin
+import PIL.PpmImagePlugin
+import PIL.TiffImagePlugin
+import PIL.PngImagePlugin
+from fretwork import log
+
+from fofix.core import Version
+from fofix.core import VFS
+
 
 def run_command(command):
     command = command.split(' ')
@@ -84,38 +100,23 @@ def cmd_args():
     return vars(parser.parse_args())
 
 
-args = cmd_args()
-
-# Disable pyOpenGL error checking if we are not asked for it.
-# This must be before *anything* that may import pyOpenGL!
-if not args['gl_error_check']:
-    disable_gl_checks()
-
-
-from fofix.core import Version
-from fofix.core import VFS
-from fofix.core.Language import _
-from fofix.game.Main import Main
-
-import fretwork
-from fretwork import log
-
-# PIL doesn't init correctly when inside py2exe, so here we kick it in butt.
-# Web search results all point to this solution:
-# http://www.py2exe.org/index.cgi/py2exeAndPIL
-import PIL.Image
-import PIL.BmpImagePlugin
-import PIL.GifImagePlugin
-import PIL.JpegImagePlugin
-import PIL.MpoImagePlugin
-import PIL.PpmImagePlugin
-import PIL.TiffImagePlugin
-import PIL.PngImagePlugin
-
-
 if __name__ == '__main__':
     is_windows = (os.name == 'nt')
     is_macos = sys.platform.startswith('darwin')
+
+    # Get command line args
+    args = cmd_args()
+
+    # Disable pyOpenGL error checking if we are not asked for it.
+    # This must be before *anything* that may import pyOpenGL!
+    if not args['gl_error_check']:
+        disable_gl_checks()
+
+    # Imports
+    from fofix.core.Language import _
+    from fofix.game.Main import Main
+
+    import fretwork
 
     # This prevents the following message being displayed on macOS:
     # ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to *path*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ before you can start the game from source:
     python setup.py build_ext --inplace --force
 
 
+### Generate translations
+
+    python setup.py msgfmt
+
+
 Start the game
 --------------
 

--- a/doc/source/quickstart/installation.rst
+++ b/doc/source/quickstart/installation.rst
@@ -28,6 +28,10 @@ From sources
 
     python setup.py build_ext --inplace --force
 
+- generate translations::
+
+    python setup.py msgfmt
+
 
 Windows
 +++++++

--- a/fofix/core/Language.py
+++ b/fofix/core/Language.py
@@ -52,7 +52,7 @@ if language:
     except Exception as x:
         log.warning("Unable to select language '%s': %s" % (language, x))
         language = None
-        Config.set("game", "language", "")
+        # Config.set("game", "language", "")
 
 _ = catalog.ugettext
 

--- a/makefile
+++ b/makefile
@@ -4,6 +4,9 @@ python:
 cmodules: 
 	python2 setup.py build_ext --inplace --force
 
+translations:
+	python2 setup.py msgfmt
+
 all:
 	python2 setup.py build_ext --inplace --force
 	find|grep -E ".py$$"|xargs python2 -m py_compile	


### PR DESCRIPTION
The user needs to compile translations before launching the game.
Adding some doc about that, plus some minor fixes, should solve the issue #205.

By the way, a small cleaning of the launcher allows to have more logs for startup errors.