### PR TITLE
fixed non ascii song titles

### DIFF
--- a/fofix/game/song/song.py
+++ b/fofix/game/song/song.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# encoding=utf8
+import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 #####################################################################
 # Frets on Fire                                                     #


### PR DESCRIPTION
I researched some info about the issue and most of the time the workaround was change the hole script to utf8 by adding the following lines at the beginning of the script.

```
# encoding=utf8
import sys
reload(sys)
sys.setdefaultencoding('utf8')
```
the code fixed the following issue when loading songs:
`UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 10: ordinal not in range(128)`