### PR TITLE
fix lobbyTitleTextPos to be properly cast as float

### DIFF
--- a/fofix/core/Theme.py
+++ b/fofix/core/Theme.py
@@ -528,7 +528,7 @@ class Theme(Task):
         self.lobbyPanelAvatarDimension = (get("lobbyPanelAvatarWidth", float, 200.00),
                                           get("lobbyPanelAvatarHeight", float, 110.00))
         self.lobbyTitleText = get("lobbyTitleText", str, "Lobby")
-        self.lobbyTitleTextPos = (get("lobbyTitleTextX", str, 0.3),
+        self.lobbyTitleTextPos = (get("lobbyTitleTextX", float, 0.3),
                                   get("lobbyTitleTextY", float, 0.015))
         self.lobbyTitleTextAlign = halign(get("lobbyTitleTextAlign", str, "CENTER"))
         self.lobbyTitleTextScale = get("lobbyTitleTextScale", float, .001)


### PR DESCRIPTION
Fix for this error trying to play any songs or using preview:

```
Traceback (most recent call last):
File "FoFiX.py", line 171, in <module>
main.run()
File "/opt/fofix-git/fofix/game/Main.py", line 131, in run
while self.engine.run():
File "/opt/fofix-git/fofix/core/GameEngine.py", line 649, in run
rtn = self.mainloop()
File "/opt/fofix-git/fofix/core/GameEngine.py", line 633, in main
self.view.render()
File "/opt/fofix-git/fofix/core/View.py", line 263, in render
layer.render(self.visibility[layer], layer == self.layers[-1])
File "/opt/fofix-git/fofix/game/Lobby.py", line 457, in render
self.engine.theme.themeLobby.renderPanels(self)
File "/opt/fofix-git/fofix/core/Theme.py", line 871, in renderPanels
lobby.fontDict[self.theme.lobbyTitleTextFont].render(self.theme.lobbyTitleText, self.theme.lobbyTitleTextPos, scale=self.theme.lobbyTitleTextScale, align=self.theme.lobbyTitleTextAlign)
File "/opt/fofix-git/fofix/core/Font.py", line 199, in render
x -= (w / 2)
TypeError: unsupported operand type(s) for -=: 'str' and 'float'
```