### PR TITLE
Dependency: bump fretwork to 0.5.0 and other deps

### DIFF
--- a/FoFiX.py
+++ b/FoFiX.py
@@ -142,7 +142,7 @@ if __name__ == '__main__':
             run_command('defaults write org.python.python ApplePersistenceIgnoreState 0')
             atexit.register(run_command, 'defaults write org.python.python ApplePersistenceIgnoreState %s' % data)
 
-    fretworkRequired = (0, 4, 0)
+    fretworkRequired = (0, 5, 0)
     reqVerStr = '.'.join([str(i) for i in fretworkRequired])
     fretworkErrorStr = '''
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Cerealizer==0.8.3
-Cython==0.27.3
+Cython==0.29.21
 numpy==1.13.3
 olefile==0.44
 Pillow==6.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.16.6
 olefile==0.46
 Pillow==6.2.2
 PyAudio==0.2.11
-pygame==1.9.3
+pygame==1.9.6
 PyOpenGL==3.1.0
 PyOpenGL-accelerate==3.1.0
 fretwork==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ PyAudio==0.2.11
 pygame==1.9.6
 PyOpenGL==3.1.5
 PyOpenGL-accelerate==3.1.5
-fretwork==0.4.0
+fretwork==0.5.0
 pypitch==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cerealizer==0.8.2
+Cerealizer==0.8.3
 Cython==0.27.3
 numpy==1.13.3
 olefile==0.44

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cerealizer==0.8.3
 Cython==0.29.21
-numpy==1.13.3
+numpy==1.16.6
 olefile==0.44
 Pillow==6.2.2
 PyAudio==0.2.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ olefile==0.46
 Pillow==6.2.2
 PyAudio==0.2.11
 pygame==1.9.6
-PyOpenGL==3.1.0
-PyOpenGL-accelerate==3.1.0
+PyOpenGL==3.1.5
+PyOpenGL-accelerate==3.1.5
 fretwork==0.4.0
 pypitch==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Cerealizer==0.8.3
 Cython==0.29.21
 numpy==1.16.6
-olefile==0.44
+olefile==0.46
 Pillow==6.2.2
 PyAudio==0.2.11
 pygame==1.9.3


### PR DESCRIPTION
This `fretwork` update let us update other requirements (NumPy, Pygame, PyOpenGL).

This update other dependencies to their latest version before Python 3 / SDL 2 (december update):
- Cerealizer
- Cython
- NumPy
- olefile
- PyOpenGL.