### PR TITLE
fix(config): encode the section value to utf-8

### DIFF
--- a/fofix/core/Config.py
+++ b/fofix/core/Config.py
@@ -53,7 +53,7 @@ class MyConfigParser(RawConfigParser):
         fp.write("[%s]\n" % sectionName)
         for key, value in sorted(sectionItems):
             if key != "__name__":
-                fp.write("%s = %s\n" % (key, str(value).replace('\n', '\n\t')))
+                fp.write("{} = {}\n".format(key, utf8(value)))
         fp.write("\n")
 
     def write(self, fp, type=0):

--- a/fofix/tests/core/test_config.py
+++ b/fofix/tests/core/test_config.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+""" Tests for fofix.core.Config """
+
+import tempfile
+import unittest
+
+from fofix.core.Config import MyConfigParser
+
+
+class MyConfigParserTest(unittest.TestCase):
+
+    def test_write(self):
+        config = MyConfigParser()
+        items = [
+            ("selected_song", "Mötley Crüe".decode("latin1")),
+        ]
+
+        with tempfile.TemporaryFile() as tmp:
+            # write a complete section manually
+            config._writeSection(tmp, "section", items)
+            tmp.seek(0)
+            lines = tmp.readlines()
+
+        self.assertIn("[section]\n", lines)
+        for option, value in items:
+            self.assertIn("{} = {}\n".format(option, value.encode("utf-8")), lines)

--- a/fofix/tests/core/test_config.py
+++ b/fofix/tests/core/test_config.py
@@ -19,7 +19,7 @@ class MyConfigParserTest(unittest.TestCase):
 
         with tempfile.TemporaryFile() as tmp:
             # write a complete section manually
-            config._writeSection(tmp, "section", items)
+            config._write_section(tmp, "section", items)
             tmp.seek(0)
             lines = tmp.readlines()
 


### PR DESCRIPTION
If the section value contains non ascii characters like "ö", then the string needs to be encoded to utf8 before writing it into a config file like `fofix.ini`.

This PR adds a test for this case and clean up the code of the module.
This PR should fix #209 (with #189).