### PR TITLE
fix(cmp): use Python 3 syntax to compare and sort data

### DIFF
--- a/fofix/core/ConfigDefs.py
+++ b/fofix/core/ConfigDefs.py
@@ -18,10 +18,14 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
+from functools import total_ordering
+
 from fofix.game.song import difficulties, parts
 from fofix.core.Language import _
 from fofix.core import Config
 
+
+@total_ordering
 class ConfigOption:
     def __init__(self, id, text):
         self.id   = id
@@ -33,11 +37,12 @@ class ConfigOption:
     def __repr__(self):
         return self.text
 
-    def __cmp__(self, other):
-        try:
-            return cmp(self.id, other.id)
-        except:
-            return -1
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __lt__(self, other):
+        return self.id < other.id
+
 
 def sortOptionsByKey(dict):
     a = {}

--- a/fofix/core/ConfigDefs.py
+++ b/fofix/core/ConfigDefs.py
@@ -44,10 +44,11 @@ class ConfigOption:
         return self.id < other.id
 
 
-def sortOptionsByKey(dict):
+def sortOptionsByKey(opts):
+    """ Sort options dictionary by keys. """
     a = {}
-    for k in dict.keys():
-        a[k] = ConfigOption(k, dict[k])
+    for k, v in opts.items():
+        a[k] = ConfigOption(k, v)
     return a
 
 # define configuration keys

--- a/fofix/core/Font.py
+++ b/fofix/core/Font.py
@@ -57,7 +57,7 @@ class Cache(object):
     def add(self, key, element):
         self.elements[key] = CacheElement(element)
         if len(self.elements) > self.maxCount:
-            keys = self.elements.keys()
+            keys = list(self.elements.keys())
             keys.sort(key=lambda e: -self.elements[e].lastUse)
             for k in keys[self.maxCount:]:
                 del self.elements[k]

--- a/fofix/core/Player.py
+++ b/fofix/core/Player.py
@@ -24,6 +24,7 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
+from functools import total_ordering
 import logging
 
 import pygame
@@ -38,6 +39,7 @@ from fofix.core import VFS
 log = logging.getLogger(__name__)
 
 
+@total_ordering
 class ConfigOption:
     """ Deprecated: also in fofix.core.ConfigDefs """
 
@@ -51,16 +53,11 @@ class ConfigOption:
     def __repr__(self):
         return self.text
 
-    def __cmp__(self, other):
-        try:
-            if self.id > other.id:
-                return 1
-            elif self.id == other.id:
-                return 0
-            else:
-                return -1
-        except Exception:
-            return -1
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __lt__(self, other):
+        return self.id < other.id
 
 
 def sortOptionsByKey(dict):

--- a/fofix/core/Player.py
+++ b/fofix/core/Player.py
@@ -60,11 +60,11 @@ class ConfigOption:
         return self.id < other.id
 
 
-def sortOptionsByKey(dict):
+def sortOptionsByKey(opts):
     """ Deprecated: also in fofix.core.ConfigDefs """
     a = {}
-    for k in dict.keys():
-        a[k] = ConfigOption(k, dict[k])
+    for k, v in opts.items():
+        a[k] = ConfigOption(k, v)
     return a
 
 # Redoing this, sir. Redoing this...

--- a/fofix/game/song/song.py
+++ b/fofix/game/song/song.py
@@ -24,6 +24,7 @@
 #####################################################################
 
 from collections import OrderedDict
+from functools import total_ordering
 import binascii
 import cPickle  # Cerealizer and sqlite3 don't seem to like each other that much...
 import copy
@@ -120,18 +121,28 @@ instrumentDiff = {
 }
 
 
+@total_ordering
 class Part(object):
     def __init__(self, uid, text, trackName):
         self.id = uid               # int uid for this instance
         self.text = text            # str friendly name for this instance
         self.trackName = trackName  # list(str) of names which the part is called in the midi
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
+        # if it's not being compared with a part, we probably want its real ID.
         if isinstance(other, Part):
-            return cmp(PART_SORTING[self.id], PART_SORTING[other.id])
+            compare = PART_SORTING[self.id] == PART_SORTING[other.id]
         else:
-            # if it's not being compared with a part, we probably want its real ID.
-            return cmp(self.id, other)
+            compare = self.id == other.id
+        return compare
+
+    def __lt__(self, other):
+        # if it's not being compared with a part, we probably want its real ID.
+        if isinstance(other, Part):
+            compare = PART_SORTING[self.id] < PART_SORTING[other.id]
+        else:
+            compare = self.id < other.id
+        return compare
 
     def __str__(self):
         return self.text
@@ -155,16 +166,17 @@ parts = {
 }
 
 
+@total_ordering
 class Difficulty(object):
     def __init__(self, uid, text):
         self.id = uid
         self.text = text
 
-    def __cmp__(self, other):
-        if isinstance(other, Difficulty):
-            return cmp(self.id, other.id)
-        else:
-            return cmp(self.id, other)
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __lt__(self, other):
+        return self.id > other.id
 
     def __str__(self):
         return self.text

--- a/fofix/game/song/song.py
+++ b/fofix/game/song/song.py
@@ -326,7 +326,7 @@ class SongInfo(object):
         if difficulty.id not in highScores:
             highScores[difficulty.id] = []
         highScores[difficulty.id].append((score, stars, name, scoreExt))
-        highScores[difficulty.id].sort(lambda a, b: {True: -1, False: 1}[a[0] > b[0]])
+        highScores[difficulty.id].sort(key=lambda h: h[0], reverse=True)
         highScores[difficulty.id] = highScores[difficulty.id][:5]
         for i, scores in enumerate(highScores[difficulty.id]):
             _score, _stars, _name, _scores_ext = scores
@@ -491,13 +491,13 @@ class SongInfo(object):
             if info.parts == []:
                 raise Exception("No tracks found in %s" % noteFileName)
             self._midiStyle = info.midiStyle
-            info.parts.sort(lambda b, a: cmp(b.id, a.id))
+            info.parts.sort(key=lambda ipart: ipart.id)
             self._parts = info.parts
             for part in info.parts:
                 if self.tutorial:
                     self._partDifficulties[part.id] = [difficulties[HAR_DIF]]
                     continue
-                info.difficulties[part.id].sort(lambda a, b: cmp(a.id, b.id))
+                info.difficulties[part.id].sort(key=lambda idiff: idiff.id)
                 self._partDifficulties[part.id] = info.difficulties[part.id]
         except Exception:
             log.warning("Note file not parsed correctly. Selected part and/or difficulty may not be available.")
@@ -3089,7 +3089,7 @@ def getAvailableLibraries(engine, library=DEFAULT_LIBRARY):
                             libName, os.path.join(libraryRoot, "library.ini")))
                         libraryRoots.append(libraryRoot)
 
-    libraries.sort(lambda a, b: cmp(a.name.lower(), b.name.lower()))
+    libraries.sort(key=lambda lib: lib.name.lower())
 
     return libraries
 
@@ -3101,7 +3101,7 @@ def getAvailableSongs(engine, library=DEFAULT_LIBRARY, includeTutorials=False, p
     if tut:
         includeTutorials = True
 
-    # Career Mode determination:
+    # Career Mode determination
     gameMode1p = engine.world.gameMode
     careerMode = gameMode1p == 2
 
@@ -3143,44 +3143,47 @@ def getAvailableSongs(engine, library=DEFAULT_LIBRARY, includeTutorials=False, p
                 song.setLocked(False)
     instrument = engine.config.get("game", "songlist_instrument")
     theInstrumentDiff = instrumentDiff[instrument]
+
+    # sort songs
     if direction == 0:
         if order == 1:
-            songs.sort(lambda a, b: cmp(a.artist.lower(), b.artist.lower()))
+            songs.sort(key=lambda k_song: k_song.artist.lower())
         elif order == 2:
-            songs.sort(lambda a, b: cmp(int(b.count + str(0)), int(a.count + str(0))))
+            songs.sort(key=lambda k_song: int(k_song.count + str(0)), reverse=True)
         elif order == 0:
-            songs.sort(lambda a, b: cmp(a.name.lower(), b.name.lower()))
+            songs.sort(key=lambda k_song: k_song.name.lower())
         elif order == 3:
-            songs.sort(lambda a, b: cmp(a.album.lower(), b.album.lower()))
+            songs.sort(key=lambda k_song: k_song.album.lower())
         elif order == 4:
-            songs.sort(lambda a, b: cmp(a.genre.lower(), b.genre.lower()))
+            songs.sort(key=lambda k_song: k_song.genre.lower())
         elif order == 5:
-            songs.sort(lambda a, b: cmp(a.year.lower(), b.year.lower()))
+            songs.sort(key=lambda k_song: k_song.year.lower())
         elif order == 6:
-            songs.sort(lambda a, b: cmp(a.diffSong, b.diffSong))
+            songs.sort(key=lambda k_song: k_song.diffSong)
         elif order == 7:
-            songs.sort(lambda a, b: cmp(theInstrumentDiff(a), theInstrumentDiff(b)))
+            songs.sort(key=lambda k_song: theInstrumentDiff(k_song))
         elif order == 8:
-            songs.sort(lambda a, b: cmp(a.icon.lower(), b.icon.lower()))
+            songs.sort(key=lambda k_song: k_song.icon.lower())
     else:
         if order == 1:
-            songs.sort(lambda a, b: cmp(b.artist.lower(), a.artist.lower()))
+            songs.sort(key=lambda k_song: k_song.artist.lower(), reverse=True)
         elif order == 2:
-            songs.sort(lambda a, b: cmp(int(a.count + str(0)), int(b.count + str(0))))
+            songs.sort(key=lambda k_song: int(k_song.count + str(0)))
         elif order == 0:
-            songs.sort(lambda a, b: cmp(b.name.lower(), a.name.lower()))
+            songs.sort(key=lambda k_song: k_song.name.lower(), reverse=True)
         elif order == 3:
-            songs.sort(lambda a, b: cmp(b.album.lower(), a.album.lower()))
+            songs.sort(key=lambda k_song: k_song.album.lower(), reverse=True)
         elif order == 4:
-            songs.sort(lambda a, b: cmp(b.genre.lower(), a.genre.lower()))
+            songs.sort(key=lambda k_song: k_song.genre.lower(), reverse=True)
         elif order == 5:
-            songs.sort(lambda a, b: cmp(b.year.lower(), a.year.lower()))
+            songs.sort(key=lambda k_song: k_song.year.lower(), reverse=True)
         elif order == 6:
-            songs.sort(lambda a, b: cmp(b.diffSong, a.diffSong))
+            songs.sort(key=lambda k_song: k_song.diffSong, reverse=True)
         elif order == 7:
-            songs.sort(lambda a, b: cmp(theInstrumentDiff(b), theInstrumentDiff(a)))
+            songs.sort(key=lambda k_song: theInstrumentDiff(k_song), reverse=True)
         elif order == 8:
-            songs.sort(lambda a, b: cmp(b.icon.lower(), a.icon.lower()))
+            songs.sort(key=lambda k_song: k_song.icon.lower(), reverse=True)
+
     return songs
 
 


### PR DESCRIPTION
To be compatible with Python 3, comparisons and sorts are reviewed :
- the `__cmp__` method is replaced with richer comparing methods, plus the `@functools.total_ordering` decorator
- the `cmp` function is removed (and not needed anymore)
- the `cmp` argument of `sort` and `sorted` is replaced with the `key` argument.

Some functions and methods are also reviewed to make the code working : 
- `fofix.core.ConfigDefs.sortOptionsByKey`: the `keys` dict. method is not adapted and is replaced with the `items` dict. method
- `fofix.game.song.song`: the `compareSongsAndTitles` function is removed because sorting is stable (https://docs.python.org/3/howto/sorting.html#sort-stability-and-complex-sorts) and already done when gettings songs info.

Ref:
- #110 
- https://portingguide.readthedocs.io/en/latest/comparisons.html