### PR TITLE
feat: use six

### DIFF
--- a/data/themes/MegaLight/CustomTheme.py
+++ b/data/themes/MegaLight/CustomTheme.py
@@ -23,11 +23,15 @@
 # MA  02110-1301, USA.                                              #
 #####################################################################
 
-from fofix.core.Theme import *
+import math
+
 from OpenGL.GL import *
 from OpenGL.GLU import *
-import math
+import six
+
+from fofix.core.Theme import *
 from fofix.game import song
+
 
 class CustomTheme(Theme):
     def __init__(self, path, name):
@@ -343,7 +347,7 @@ class CustomSetlist(Setlist):
                         score = "%s %.1f%%" % (score, (float(notesHit) / notesTotal) * 100.0)
                     if noteStreak != 0:
                         score = "%s (%d)" % (score, noteStreak)
-                font.render(unicode(score), (x + .15, y),     scale = scale)
+                font.render(six.u(score), (x + .15, y),     scale = scale)
                 font.render(name,       (x + .15, y + fh),     scale = scale)
                 y += 2 * fh
         elif isinstance(item, song.LibraryInfo):

--- a/fofix/core/Config.py
+++ b/fofix/core/Config.py
@@ -22,6 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,        #
 # MA  02110-1301, USA.                                              #
 #####################################################################
+
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
@@ -33,9 +34,10 @@ import os
 import StringIO
 import sys
 
-from fretwork.unicode import utf8, unicodify
+# from fretwork.unicode import utf8, unicodify
 
 from fofix.core import VFS
+from fofix.core.utils import utf8, unicodify
 
 
 log = logging.getLogger(__name__)

--- a/fofix/core/Config.py
+++ b/fofix/core/Config.py
@@ -28,13 +28,14 @@ from __future__ import division
 from __future__ import absolute_import
 
 from collections import MutableMapping, namedtuple
-from ConfigParser import RawConfigParser
 import logging
 import os
-import StringIO
 import sys
 
 # from fretwork.unicode import utf8, unicodify
+from six.moves.configparser import RawConfigParser
+from six import StringIO
+import six
 
 from fofix.core import VFS
 from fofix.core.utils import utf8, unicodify
@@ -71,7 +72,7 @@ class MyConfigParser(RawConfigParser):
                 self._write_section(fp, section, self.items(section))
 
     def read(self, filenames):
-        if isinstance(filenames, basestring):
+        if isinstance(filenames, six.string_types):
             filenames = [filenames]
 
         read_ok = []
@@ -86,7 +87,7 @@ class MyConfigParser(RawConfigParser):
                 config_lines = [line for line in config_lines
                                 if line.strip()[0:2] != '//']
                 config_data = '\n'.join(config_lines)
-                str_fp = StringIO.StringIO(config_data)
+                str_fp = StringIO(config_data)
                 self.readfp(str_fp, filename)
             except IOError:
                 continue
@@ -201,7 +202,7 @@ class Config(object):
                 return default  # allows None-default bools to return None
             else:
                 return False
-        elif issubclass(type, basestring):
+        elif issubclass(type, six.string_types):
             return unicodify(value)
         else:
             try:

--- a/fofix/core/Data.py
+++ b/fofix/core/Data.py
@@ -49,12 +49,12 @@ RIGHT = '>'
 STAR3 = STAR1
 STAR4 = STAR2
 
-# STAR1 = unicode('\x10')
-# STAR2 = unicode('\x11')
-# LEFT  = unicode('\x12')
-# RIGHT = unicode('\x13')
-# STAR3 = unicode('\x14')
-# STAR4 = unicode('\x15')
+# STAR1 = six.u('\x10')
+# STAR2 = six.u('\x11')
+# LEFT  = six.u('\x12')
+# RIGHT = six.u('\x13')
+# STAR3 = six.u('\x14')
+# STAR4 = six.u('\x15')
 
 
 class Data(object):

--- a/fofix/core/Image.py
+++ b/fofix/core/Image.py
@@ -28,6 +28,7 @@ import logging
 from OpenGL.GL import *
 from PIL import Image
 import numpy as np
+import six
 
 from fofix.core import cmgl
 from fofix.core.Texture import Texture
@@ -198,7 +199,7 @@ class ImgDrawing(object):
         # Detect the type of data passed in
         if isinstance(ImgData, file):
             self.ImgData = ImgData.read()
-        elif isinstance(ImgData, basestring):
+        elif isinstance(ImgData, six.string_types):
             self.texture = Texture(ImgData)
         elif isinstance(ImgData, Image.Image): # let a PIL image be passed in
             self.texture = Texture()
@@ -206,7 +207,7 @@ class ImgDrawing(object):
 
         # Make sure we have a valid texture
         if not self.texture:
-            if isinstance(ImgData, basestring):
+            if isinstance(ImgData, six.string_types):
                 e = "Unable to load texture for %s." % ImgData
             else:
                 e = "Unable to load texture for SVG file."

--- a/fofix/core/Resource.py
+++ b/fofix/core/Resource.py
@@ -28,10 +28,11 @@ import sys
 import time
 import shutil
 import stat
-from Queue import Queue, Empty
 from threading import Thread, BoundedSemaphore
 
 from fretwork.task import Task
+from six.moves.queue import Empty
+from six.moves.queue import Queue
 
 from fofix.core.VFS import getWritableResourcePath
 from fofix.core import Version

--- a/fofix/core/Theme.py
+++ b/fofix/core/Theme.py
@@ -33,6 +33,7 @@ import sys
 from OpenGL.GL import *
 from OpenGL.GLU import *
 from fretwork.task import Task
+import six
 
 from fofix.core import Config
 from fofix.core import Version
@@ -85,7 +86,7 @@ def valign(value, default='middle'):
 def hexToColor(color):
     ''' Convert hexadecimal color string to tuple containing rgb or rgba values '''
 
-    if not (isinstance(color, str) or isinstance(color, unicode)):
+    if not (isinstance(color, str) or isinstance(color, six.text_type)):
         raise TypeError('Invalid input type: {}'.format(type(color)))
 
     elif color[0] != '#':
@@ -2298,7 +2299,7 @@ class Setlist:
                             score = "%s %.1f%%" % (score, (float(notesHit) / notesTotal) * 100.0)
                         if noteStreak != 0:
                             score = "%s (%d)" % (score, noteStreak)
-                    font.render(unicode(score), (x + .15, y),     scale=scale)
+                    font.render(six.u(score), (x + .15, y),     scale=scale)
                     font.render(name,       (x + .15, y + fh),     scale=scale)
                     y += 2 * fh
             elif isinstance(item, song.LibraryInfo):
@@ -2386,7 +2387,7 @@ class Setlist:
                             score = "%s %.1f%%" % (score, (float(notesHit) / notesTotal) * 100.0)
                         if noteStreak != 0:
                             score = "%s (%d)" % (score, noteStreak)
-                    font.render(unicode(score), (x + .15, y),     scale=scale)
+                    font.render(six.u(score), (x + .15, y),     scale=scale)
                     font.render(name,       (x + .15, y + fh),     scale=scale)
                     y += 2 * fh + f / 4.0
         elif self.setlist_type == 3:

--- a/fofix/core/Version.py
+++ b/fofix/core/Version.py
@@ -25,6 +25,8 @@ import os
 import re
 import sys
 
+import six
+
 
 MAJOR_VERSION = 4
 MINOR_VERSION = 0
@@ -93,7 +95,7 @@ def version():
     if isWindowsExe():
         # stump: if we've been py2exe'd, read our version string from the exe.
         import win32api
-        us = os.path.abspath(unicode(sys.executable, sys.getfilesystemencoding()))
+        us = os.path.abspath(six.u(sys.executable, sys.getfilesystemencoding()))
         version = win32api.GetFileVersionInfo(us, r'\StringFileInfo\%04x%04x\ProductVersion' % win32api.GetFileVersionInfo(us, r'\VarFileInfo\Translation')[0])
     else:
         version = "%s %s" % (versionNum(), revision())

--- a/fofix/core/utils.py
+++ b/fofix/core/utils.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import functools
+import warnings
+
+import six
+
+
+def deprecated(deprecated_in=None, removed_in=None, details=""):
+    """Decorator for deprecation
+
+    See https://pypi.org/project/deprecation/
+    """
+    def _function_wrapper(func):
+
+        @functools.wraps(func)
+        def _inner(*args, **kwargs):
+            deprecated_in_msg, removed_in_msg, details_msg = "", "", ""
+            if deprecated_in is not None:
+                deprecated_in_msg = " as of %s" % deprecated_in
+            if removed_in is not None:
+                removed_in_msg = " and will be removed in %s" % removed_in
+            if details:
+                details_msg = ": %s" % details
+
+            message = "%s is deprecated%s%s%s" % (func.__name__, deprecated_in_msg, removed_in_msg, details_msg)
+            warnings.warn(message, category=DeprecationWarning, stacklevel=2)
+
+            return func(*args, **kwargs)
+
+        return _inner
+    return _function_wrapper
+
+
+@deprecated(details="Use fretwork.unicode.unicodify (v1) instead")
+def unicodify(s):
+    """Return a unicode string"""
+    if isinstance(s, six.binary_type):
+        return s.decode('utf-8')
+
+    if isinstance(s, six.text_type):
+        return s
+
+    return str(s)
+
+
+@deprecated(details="Use fretwork.unicode.utf8 (v1) instead")
+def utf8(s):
+    """Return a valid UTF-8 bytestring"""
+    return unicodify(s).encode("utf-8")

--- a/fofix/game/Dialogs.py
+++ b/fofix/game/Dialogs.py
@@ -38,6 +38,7 @@ import os
 from OpenGL.GL import *
 # from fretwork.unicode import unicodify
 import pygame
+import six
 
 from fofix.core.View import Layer, BackgroundLayer
 from fofix.core.Input import KeyListener
@@ -521,7 +522,7 @@ class FileChooser(BackgroundLayer, KeyListener):
         return fileName
 
     def getFiles(self):
-        files = [u".."]
+        files = [six.u("..")]
         for fn in os.listdir(self.path):
             if fn.startswith("."):
                 continue
@@ -543,17 +544,17 @@ class FileChooser(BackgroundLayer, KeyListener):
         driveLetters = []
         for drive in string.letters[len(string.letters) // 2:]:
             if win32file.GetDriveType(drive + ":") == win32file.DRIVE_FIXED:
-                driveLetters.append(drive + u":\\")
+                driveLetters.append(drive + six.u(":\\"))
         return driveLetters
 
     def updateFiles(self):
         if self.menu:
             self.engine.view.popLayer(self.menu)
 
-        if self.path == u"toplevel" and os.name != "nt":
-            self.path = u"/"
+        if self.path == six.u("toplevel") and os.name != "nt":
+            self.path = six.u("/")
 
-        if self.path == u"toplevel":
+        if self.path == six.u("toplevel"):
             self.menu = Menu(self.engine, choices=[(self._getFileText(f), self._getFileCallback(f)) for f in self.getDisks()], onClose=self.close, onCancel=self.cancel)
         else:
             self.menu = Menu(self.engine, choices=[(self._getFileText(f), self._getFileCallback(f)) for f in self.getFiles()], onClose=self.close, onCancel=self.cancel)
@@ -569,14 +570,14 @@ class FileChooser(BackgroundLayer, KeyListener):
                     self.menu = None
                     return
 
-        if self.path == u"toplevel":
-            self.path = u""
+        if self.path == six.u("toplevel"):
+            self.path = six.u("")
         path = os.path.abspath(os.path.join(self.path, fileName))
 
         if os.path.isdir(path):
 
-            if path == self.path and fileName == u"..":
-                self.path = u"toplevel"
+            if path == self.path and fileName == six.u(".."):
+                self.path = six.u("toplevel")
             else:
                 self.path = path
             self.updateFiles()
@@ -1870,7 +1871,7 @@ def getKey(engine, prompt, key=None, specialKeyList=None):
     return d.key
 
 
-def chooseFile(engine, masks=["*.*"], path=u".", prompt=_("Choose a File"), dirSelect=False):
+def chooseFile(engine, masks=["*.*"], path=six.u("."), prompt=_("Choose a File"), dirSelect=False):
     """
     Ask the user to select a file.
 

--- a/fofix/game/Dialogs.py
+++ b/fofix/game/Dialogs.py
@@ -35,9 +35,9 @@ import logging
 import math
 import os
 
-import pygame
 from OpenGL.GL import *
-from fretwork.unicode import unicodify
+# from fretwork.unicode import unicodify
+import pygame
 
 from fofix.core.View import Layer, BackgroundLayer
 from fofix.core.Input import KeyListener
@@ -49,6 +49,7 @@ from fofix.game.Menu import Menu
 from fofix.core import Microphone
 from fofix.core import Player
 from fofix.core import Config
+from fofix.core.utils import unicodify
 
 
 log = logging.getLogger(__name__)

--- a/fofix/game/GameResultsScene.py
+++ b/fofix/game/GameResultsScene.py
@@ -33,13 +33,15 @@ import binascii
 import hashlib
 import logging
 import random
-import urllib
 import os
 
 from OpenGL.GL import *
 from fretwork.audio import Sound
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.request import urlopen
 import cerealizer
 import pygame
+import six
 
 from fofix.core.Image import drawImage
 from fofix.core.Scene import Scene
@@ -528,7 +530,7 @@ class GameResultsScene(Scene):
             d["scores"] = binascii.hexlify(cerealizer.dumps(scores))
             d["scores_ext"] = binascii.hexlify(cerealizer.dumps(scores_ext))
             url = self.engine.config.get("network", "uploadurl")
-            data = urllib.urlopen(url + "?" + urllib.urlencode(d)).read()
+            data = urlopen(url + "?" + urlencode(d)).read()
             log.debug("Score upload result: %s" % data)
             return data   #MFH - want to return the actual result data.
         except Exception as e:
@@ -1245,10 +1247,10 @@ class GameResultsScene(Scene):
                     score = "%s %.1f%%" % (score, (float(notesHit) / notesTotal) * 100.0)
                 if noteStreak != 0:
                     score = "%s (%d)" % (score, noteStreak)
-                font.render(unicode(score), (x + .05, y + self.offset),   scale = scale)
+                font.render(six.u(score), (x + .05, y + self.offset),   scale = scale)
                 options = ""
                 w2, h2 = font.getStringSize(options, scale = scale / 2)
-                font.render(unicode(options), (.6 - w2, y + self.offset),   scale = scale / 2)
+                font.render(six.u(options), (.6 - w2, y + self.offset),   scale = scale / 2)
                 # evilynux - Fixed star size following Font render bugfix
                 # akedrou  - Fixed stars to render as stars after custom glyph removal... ...beautiful yPos
                 self.engine.drawStarScore(w, h, x+.6, 1.0-((y+self.offset+h2)/self.engine.data.fontScreenBottom), stars, scale * 15)

--- a/fofix/game/Menu.py
+++ b/fofix/game/Menu.py
@@ -30,6 +30,7 @@ import os
 
 from OpenGL.GL import *
 import pygame
+import six
 
 from fofix.core.Input import KeyListener
 from fofix.core.Image import drawImage
@@ -62,7 +63,7 @@ class Choice:
         :param tipText: the tip for the item
         :type tipText: string
         """
-        self.text       = unicode(text)
+        self.text       = six.u(text)
         self.callback   = callback
         self.name       = name
         self.values     = values

--- a/fofix/game/song/song.py
+++ b/fofix/game/song/song.py
@@ -39,7 +39,7 @@ import urllib
 
 from fretwork import midi
 from fretwork.audio import StreamingSound
-from fretwork.unicode import utf8
+# from fretwork.unicode import utf8
 import cerealizer
 
 from fofix.core import Config
@@ -48,6 +48,7 @@ from fofix.core import Version
 from fofix.core.Language import _
 from fofix.core.Theme import *
 from fofix.core.Theme import hexToColor, colorToHex
+from fofix.core.utils import utf8
 from fofix.game.song.songconstants import *
 
 

--- a/fofix/game/song/song.py
+++ b/fofix/game/song/song.py
@@ -26,7 +26,6 @@
 from collections import OrderedDict
 from functools import total_ordering
 import binascii
-import cPickle  # Cerealizer and sqlite3 don't seem to like each other that much...
 import copy
 import glob
 import hashlib
@@ -35,12 +34,15 @@ import os
 import random
 import re
 import time
-import urllib
 
 from fretwork import midi
 from fretwork.audio import StreamingSound
 # from fretwork.unicode import utf8
+from six.moves import cPickle  # Cerealizer and sqlite3 don't seem to like each other that much
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.request import urlopen
 import cerealizer
+import six
 
 from fofix.core import Config
 from fofix.core import VFS
@@ -576,7 +578,7 @@ class SongInfo(object):
     def getScoreHash(self, difficulty, score, stars, name):
         if isinstance(difficulty, Difficulty):
             difficulty = difficulty.id
-        return hashlib.sha1("%d%d%d%s" % (difficulty, score, stars, name)).hexdigest()
+        return hashlib.sha1(six.b("%d%d%d%s" % (difficulty, score, stars, six.b(name)))).hexdigest()
 
     @property
     def delay(self):
@@ -641,7 +643,7 @@ class SongInfo(object):
                 "version":  "%s-3.100" % Version.PROGRAM_NAME,
                 "songPart": part
             }
-            data = urllib.urlopen(url + "?" + urllib.urlencode(d)).read()
+            data = urlopen(url + "?" + urlencode(d)).read()
             log.debug("Score upload result: %s" % data)
             return data  # want to return the actual result data.
         except Exception as e:
@@ -1898,7 +1900,7 @@ class Song(object):
                     self.songTracks[instrument] = []
                 try:
                     self.songTracks[instrument].append(StreamingSound(
-                        self.engine.audio.getChannel(channel), filePath))
+                        self.engine.audio.getChannel(channel), six.b(filePath)))
                     channel += 1
                 except Exception as e:
                     log.error("Unable to load song track: %s" % e)

--- a/fofix/tests/core/test_config.py
+++ b/fofix/tests/core/test_config.py
@@ -6,6 +6,8 @@
 import tempfile
 import unittest
 
+import six
+
 from fofix.core.Config import MyConfigParser
 
 
@@ -14,7 +16,7 @@ class MyConfigParserTest(unittest.TestCase):
     def test_write(self):
         config = MyConfigParser()
         items = [
-            ("selected_song", "Mötley Crüe".decode("latin1")),
+            ("selected_song", six.u("Mötley Crüe")),
         ]
 
         with tempfile.TemporaryFile() as tmp:
@@ -23,6 +25,6 @@ class MyConfigParserTest(unittest.TestCase):
             tmp.seek(0)
             lines = tmp.readlines()
 
-        self.assertIn("[section]\n", lines)
+        self.assertIn(six.b("[section]\n"), lines)
         for option, value in items:
-            self.assertIn("{} = {}\n".format(option, value.encode("utf-8")), lines)
+            self.assertIn(six.b("{} = {}\n".format(option, value.encode("utf-8"))), lines)

--- a/fofix/tests/core/test_resource.py
+++ b/fofix/tests/core/test_resource.py
@@ -4,7 +4,7 @@
 import time
 import unittest
 
-from Queue import Queue
+from six.moves.queue import Queue
 from threading import BoundedSemaphore
 
 from fofix.core.Resource import Loader

--- a/fofix/tests/core/test_utils.py
+++ b/fofix/tests/core/test_utils.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import unittest
+import warnings
+
+import six
+
+from fofix.core.utils import deprecated
+from fofix.core.utils import unicodify
+from fofix.core.utils import utf8
+
+
+class UtilsTest(unittest.TestCase):
+
+    def test_deprecated_empty(self):
+        @deprecated()
+        def func(val):
+            return val
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            f = func(42)
+            self.assertEqual(f, 42)
+
+        self.assertEqual(len(caught_warnings), 1)
+        self.assertEqual(caught_warnings[0].category, DeprecationWarning)
+        self.assertEqual(str(caught_warnings[0].message), "func is deprecated")
+
+    def test_deprecated_details(self):
+        details = "Use another func"
+
+        @deprecated(details=details)
+        def func_details(val):
+            return val
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            f = func_details(42)
+            self.assertEqual(f, 42)
+
+        message = "func_details is deprecated: %s" % details
+        self.assertEqual(len(caught_warnings), 1)
+        self.assertEqual(caught_warnings[0].category, DeprecationWarning)
+        self.assertEqual(str(caught_warnings[0].message), message)
+
+    def test_unicodify(self):
+        simple_s = "Jurgen"
+        accent_s = "Jürgen"
+        simple_b = six.b("Jurgen")
+        simple_u = six.u("Jürgen")
+        u_simple_s = unicodify(simple_s)
+        u_accent_s = unicodify(accent_s)
+        u_simple_b = unicodify(simple_b)
+        u_simple_u = unicodify(simple_u)
+
+        self.assertIs(type(u_simple_s), six.text_type)
+        self.assertIs(type(u_accent_s), six.text_type)
+        self.assertIs(type(u_simple_b), six.text_type)
+        self.assertIs(type(u_simple_u), six.text_type)
+        self.assertEqual(u_simple_s, simple_s)
+        self.assertEqual(u_accent_s, six.u("J\xfcrgen"))
+        self.assertEqual(u_simple_b, simple_s)
+        self.assertEqual(u_simple_u, simple_u)
+
+    def test_utf8(self):
+        simple_s = "Jurgen"
+        accent_s = "Jürgen"
+        simple_b = six.b("Jurgen")
+        u_simple_s = utf8(simple_s)
+        u_accent_s = utf8(accent_s)
+        u_simple_b = utf8(simple_b)
+
+        self.assertIs(type(u_simple_s), six.binary_type)
+        self.assertIs(type(u_accent_s), six.binary_type)
+        self.assertIs(type(u_simple_b), six.binary_type)
+        self.assertEqual(u_simple_s, simple_b)
+        self.assertEqual(u_accent_s, u_accent_s)
+        self.assertEqual(u_simple_b, simple_b)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ fretwork==0.5.0
 pypitch==1.3
 pycollada==0.7.1
 videoplayer==1.0
+six==1.16.0


### PR DESCRIPTION
The game is using `six` to keep python2 compatibility during the migration.

Plus, `fretwork.unicode.utf8` and `fretwork.unicode.unicodify` functions are not python3 compatible with fretwork v0.5. Then they are adapted with `six` and marked as deprecated.

Ref #110