### PR TITLE
fix(py3): use python3 compat' methods and objects

### DIFF
--- a/data/themes/MegaLight V4/CustomRMLayers.py
+++ b/data/themes/MegaLight V4/CustomRMLayers.py
@@ -1,5 +1,5 @@
-
 from fofix.game.guitarscene import Rockmeter
+
 
 class CoOpMeter(Rockmeter.Group):
     def __init__(self, stage, section):
@@ -9,8 +9,6 @@ class CoOpMeter(Rockmeter.Group):
         self.ySpacingExpr = self.getexpr("yspacing", "0.0")
         self.ySpacing = 0.0
         self.condition = "True"
-
-        print self.layers.values()
 
     def updateLayer(self, playerNum):
         super(CoOpMeter, self).updateLayer(playerNum)
@@ -41,11 +39,11 @@ class CoOpMeter(Rockmeter.Group):
                 layer.position = [layer.position[n] + self.position[n] for n in range(2)]
                 layer.position[1] -= (self.ySpacing*scale/h)*(i/2)
 
-            #flips across screen for every other player
+            # flips across screen for every other player
             if i % 2 == 1:
                 layer.position[0] = w - layer.position[0]
                 layer.scale[0] *= -1
                 layer.angle *= -1
 
-            #layer.scale = [s/(2.0*(len(self.stage.scene.players)/2)) for s in layer.scale]
+            # layer.scale = [s/(2.0*(len(self.stage.scene.players)/2)) for s in layer.scale]
             layer.render(visibility, playerNum)

--- a/fofix/core/Config.py
+++ b/fofix/core/Config.py
@@ -50,6 +50,8 @@ def decode_string(data):
         return data.decode('utf-8')
     except UnicodeDecodeError:
         return data.decode('latin-1')
+    except AttributeError:
+        return data
 
 
 class MyConfigParser(RawConfigParser):

--- a/fofix/core/GameEngine.py
+++ b/fofix/core/GameEngine.py
@@ -260,10 +260,10 @@ class GameEngine(object):
         fullscreen    = self.config.get("video", "fullscreen")
         multisamples  = self.config.get("video", "multisamples")
         self.video.setMode((width, height), fullscreen=fullscreen, multisamples=multisamples)
-        log.debug("OpenGL version: " + glGetString(GL_VERSION))
-        log.debug("OpenGL vendor: " + glGetString(GL_VENDOR))
-        log.debug("OpenGL renderer: " + glGetString(GL_RENDERER))
-        log.debug("OpenGL extensions: " + ' '.join(sorted(glGetString(GL_EXTENSIONS).split())))
+        log.debug("OpenGL version: %s" % glGetString(GL_VERSION))
+        log.debug("OpenGL vendor: %s" % glGetString(GL_VENDOR))
+        log.debug("OpenGL renderer: %s" % glGetString(GL_RENDERER))
+        # log.debug("OpenGL extensions: " + ' '.join(sorted(glGetString(GL_EXTENSIONS).split())))
 
         if self.video.default:
             self.config.set("video", "fullscreen", False)

--- a/fofix/core/Image.py
+++ b/fofix/core/Image.py
@@ -23,6 +23,7 @@
 #####################################################################
 
 from __future__ import with_statement
+from io import IOBase
 import logging
 
 from OpenGL.GL import *
@@ -197,7 +198,7 @@ class ImgDrawing(object):
         self.filename = ImgData
 
         # Detect the type of data passed in
-        if isinstance(ImgData, file):
+        if isinstance(ImgData, IOBase):
             self.ImgData = ImgData.read()
         elif isinstance(ImgData, six.string_types):
             self.texture = Texture(ImgData)

--- a/fofix/core/Language.py
+++ b/fofix/core/Language.py
@@ -54,7 +54,7 @@ if language:
         language = None
         # Config.set("game", "language", "")
 
-_ = catalog.ugettext
+_ = catalog.gettext
 
 # Define the config key again now that we have some options for it
 langOptions = {"": "English"}

--- a/fofix/core/Player.py
+++ b/fofix/core/Player.py
@@ -602,7 +602,12 @@ class Controls:
         kills = []
 
         for i, config in enumerate(self.config):
-            if self.type[i] in DRUMTYPES: #drum set
+            if self.type[i] is None:
+                # self.type[i] = -1
+                controlMapping = {}
+                continue
+
+            if self.type[i] in DRUMTYPES:  # drum set
                 drum1s.extend([CONTROLS[i][DRUM1], CONTROLS[i][DRUM1A]])
                 drum2s.extend([CONTROLS[i][DRUM2], CONTROLS[i][DRUM2A]])
                 drum3s.extend([CONTROLS[i][DRUM3], CONTROLS[i][DRUM3A]])

--- a/fofix/core/Shader.py
+++ b/fofix/core/Shader.py
@@ -24,7 +24,6 @@ import logging
 import os
 import sys
 import time
-import string
 from random import random
 
 import pygame.image
@@ -137,7 +136,7 @@ class ShaderList:
         """
 
         for line in open(fname):
-            aline = line[:string.find(line, ";")]
+            aline = line[:line.find(";")]
             aline = aline.split(' ')
             if '(' in aline[0]:
                 break

--- a/fofix/core/Theme.py
+++ b/fofix/core/Theme.py
@@ -27,7 +27,6 @@ import imp
 import logging
 import math
 import os
-import string
 import sys
 
 from OpenGL.GL import *
@@ -1109,7 +1108,7 @@ class Setlist:
                     text = "    " + text
 
             if isinstance(item, song.TitleInfo) or isinstance(item, song.SortTitleInfo):
-                text = string.upper(text)
+                text = text.upper()
 
             scale = lfont.scaleText(text, maxwidth=0.440)
 
@@ -1137,7 +1136,7 @@ class Setlist:
                 glColor3f(c1, c2, c3)
 
                 # Force uppercase display for artist name
-                text = string.upper(item.artist) + suffix + yeartag
+                text = item.artist.upper() + suffix + yeartag
 
                 # automatically scale artist name and year
                 scale = lfont.scaleText(text, maxwidth=0.440, scale=scale)
@@ -1225,7 +1224,7 @@ class Setlist:
                 if scene.tiersPresent:
                     text = "    " + text
             if isinstance(item, song.TitleInfo) or isinstance(item, song.SortTitleInfo):
-                text = string.upper(text)
+                text = text.upper()
             scale = font.scaleText(text, maxwidth=0.45)
             font.render(text, (self.song_listcd_list_xpos, .09*(n+1)), scale=scale)
             if isinstance(item, song.SongInfo) and not item.getLocked():
@@ -1243,7 +1242,7 @@ class Setlist:
                 c1, c2, c3 = self.artist_text_color
                 glColor4f(c1, c2, c3, 1)
 
-                text = string.upper(item.artist) + suffix + yeartag
+                text = item.artist.upper() + suffix + yeartag
 
                 scale = font.scaleText(text, maxwidth=0.4, scale=scale)
                 font.render(text, (self.song_listcd_list_xpos + .05, .09*(n+1)+.05), scale=scale)
@@ -1311,7 +1310,7 @@ class Setlist:
             maxwidth = .55
 
             if isinstance(item, song.TitleInfo) or isinstance(item, song.SortTitleInfo):
-                text = string.upper(text)
+                text = text.upper()
 
             scale = .0015
             wt, ht = font.getStringSize(text, scale=scale)
@@ -1419,7 +1418,7 @@ class Setlist:
                     text = "    " + text
 
             if isinstance(item, song.TitleInfo) or isinstance(item, song.SortTitleInfo):
-                text = string.upper(text)
+                text = text.upper()
 
             scale = sfont.scaleText(text, maxwidth=0.440)
 
@@ -1447,7 +1446,7 @@ class Setlist:
                 glColor3f(c1, c2, c3)
 
                 # Force uppercase display for artist name
-                text = string.upper(item.artist) + suffix + yeartag
+                text = item.artist.upper() + suffix + yeartag
 
                 # automatically scale artist name and year
                 scale = lfont.scaleText(text, maxwidth=0.440, scale=scale)
@@ -1580,7 +1579,7 @@ class Setlist:
                     text = "    " + text
 
             elif isinstance(item, song.TitleInfo) or isinstance(item, song.SortTitleInfo):
-                text = string.upper(text)
+                text = text.upper()
 
             scale = font.scaleText(text, maxwidth=0.45)
             font.render(text, (self.song_listcd_list_xpos, .09*(n+1)), scale=scale)
@@ -1599,7 +1598,7 @@ class Setlist:
                 scale = .0014
                 c1, c2, c3 = self.artist_selected_color
                 glColor4f(c1, c2, c3, 1)
-                text = string.upper(item.artist) + suffix + yeartag
+                text = item.artist.upper() + suffix + yeartag
 
                 scale = font.scaleText(text, maxwidth=0.4, scale=scale)
                 font.render(text, (self.song_listcd_list_xpos + .05, .09*(n+1)+.05), scale=scale)
@@ -1704,7 +1703,7 @@ class Setlist:
             # Force uppercase display for Career titles
             if isinstance(item, song.TitleInfo) or isinstance(item, song.SortTitleInfo):
                 maxwidth = .55
-                text = string.upper(text)
+                text = text.upper()
 
             scale = .0015
             wt, ht = font.getStringSize(text, scale=scale)
@@ -2412,7 +2411,7 @@ class Setlist:
                 c1, c2, c3 = self.artist_text_color
                 glColor3f(c1, c2, c3)
 
-                text = string.upper(text)
+                text = text.upper()
                 font.render(text, (.095, .44), scale=scale)
 
                 if scene.img_diff3 is not None:
@@ -2420,7 +2419,7 @@ class Setlist:
                     wfactor1 = 13.0 / imgwidth
 
                 albumtag = item.album
-                albumtag = string.upper(albumtag)
+                albumtag = albumtag.upper()
                 wt, ht = font.getStringSize(albumtag, scale=scale)
 
                 while wt > .21:

--- a/fofix/game/Dialogs.py
+++ b/fofix/game/Dialogs.py
@@ -540,9 +540,10 @@ class FileChooser(BackgroundLayer, KeyListener):
         return files
 
     def getDisks(self):
-        import win32file, string
+        import win32file
+        import string
         driveLetters = []
-        for drive in string.letters[len(string.letters) // 2:]:
+        for drive in string.ascii_letters[::-1][len(string.letters) // 2:]:
             if win32file.GetDriveType(drive + ":") == win32file.DRIVE_FIXED:
                 driveLetters.append(drive + six.u(":\\"))
         return driveLetters

--- a/fofix/game/MainMenu.py
+++ b/fofix/game/MainMenu.py
@@ -27,7 +27,6 @@
 import logging
 import os
 import random
-import string
 import warnings
 
 from fretwork.audio import Music
@@ -133,7 +132,7 @@ class MainMenu(BackgroundLayer):
             allfiles = os.listdir(filepath)
             for name in allfiles:
                 if os.path.splitext(name)[1] == ".ogg":
-                    if string.find(name, "menu") > -1:
+                    if name.find("menu") > -1:
                         self.files.append(name)
 
         ## get a random music

--- a/fofix/tests/core/test_config.py
+++ b/fofix/tests/core/test_config.py
@@ -16,15 +16,15 @@ class MyConfigParserTest(unittest.TestCase):
     def test_write(self):
         config = MyConfigParser()
         items = [
-            ("selected_song", six.u("Mötley Crüe")),
+            ("selected_song", six.b("Mötley Crüe").decode("latin-1")),
         ]
 
-        with tempfile.TemporaryFile() as tmp:
+        with tempfile.TemporaryFile(mode='w+') as tmp:
             # write a complete section manually
             config._write_section(tmp, "section", items)
             tmp.seek(0)
             lines = tmp.readlines()
 
-        self.assertIn(six.b("[section]\n"), lines)
+        self.assertIn("[section]\n", lines)
         for option, value in items:
-            self.assertIn(six.b("{} = {}\n".format(option, value.encode("utf-8"))), lines)
+            self.assertIn("{} = {}\n".format(option, value.encode("utf-8")), lines)

--- a/fofix/tests/core/test_resource.py
+++ b/fofix/tests/core/test_resource.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import time
+import traceback
 import unittest
 
 from six.moves.queue import Queue
@@ -74,15 +75,15 @@ class LoaderTest(unittest.TestCase):
 
     def test_finish(self):
         # not canceled
-        ## with exception
+        # - with exception
         err = TypeError("unsupported operand type(s) for +: 'int' and 'str'")
-        self.loader.exception = [err.__class__, err, ""]
+        self.loader.exception = [err.__class__, err, traceback.print_stack()]
         with self.assertRaises(TypeError) as cm:
             self.loader.finish()
         self.assertEqual(cm.expected, err.__class__)
         self.assertEqual(str(cm.exception), str(err))
 
-        ## without exception
+        # - without exception
         self.loader.exception = None
         self.loader.load()
         self.loader.finish()


### PR DESCRIPTION
Some methods and objects need to be changed for python 2 - python 3 compatibility:
- `print` needs parentheses
- `str` native methods can be used instead of old `string` methods
- `IOBase` should replace `file` keyword
- `gettext` should replace `ugettext`
- `string.letters` should be replaced with `string.ascii_letters`
- convert bytes to string and vice versa
- use `traceback` to get all exception
- handle the `None` side case in instrument types.

Ref #110