### PR TITLE
ci(tests): use py3 as default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,15 +13,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7]
+        python-version: ["3.7"]
         experimental: [false]
 
         include:
-          - python-version: 3.6
+          - python-version: "2.7"
             experimental: true
-          - python-version: 3.7
+          - python-version: "3.10"
             experimental: true
-          - python-version: 3.8
+          - python-version: "3.11"
+            experimental: true
+          - python-version: "3.12"
+            experimental: true
+          - python-version: "3.13"
+            experimental: true
+          - python-version: "3.14"
             experimental: true
 
     steps:


### PR DESCRIPTION
* Replace python 2 with python 3.7 as default version
* Add python 3.9 and python 3.10 as optional
* Remove support for python 3.6 as it is not maintained anymore.

Ref #110