### PR TITLE
fix(py3): use right types from py2

### DIFF
--- a/fofix/core/Settings.py
+++ b/fofix/core/Settings.py
@@ -68,7 +68,7 @@ class ConfigChoice(Menu.Choice):
         o = config.prototype[section][option]
         v = config.get(section, option)
         if isinstance(o.options, dict):
-            values     = o.options.values()
+            values = list(o.options.values())
             values.sort()
             try:
                 valueIndex = values.index(o.options[v])
@@ -82,7 +82,7 @@ class ConfigChoice(Menu.Choice):
                 valueIndex = 0
         else:
             raise RuntimeError("No usable options for %s.%s." % (section, option))
-        Menu.Choice.__init__(self, text = o.text, callback = self.change, values = values, valueIndex = valueIndex, tipText = tipText)
+        Menu.Choice.__init__(self, text=o.text, callback=self.change, values=values, valueIndex=valueIndex, tipText=tipText)
 
     def change(self, value):
         o = self.config.prototype[self.section][self.option]

--- a/fofix/game/Menu.py
+++ b/fofix/game/Menu.py
@@ -275,7 +275,7 @@ class Menu(Layer, KeyListener):
         self.tipDelay = 700
         self.tipTimerEnabled = False
         self.tipScroll = 0
-        self.tipScrollB = None
+        self.tipScrollB = 0
         self.tipScrollSpace = self.engine.theme.menuTipTextScrollSpace
         self.tipScale = self.engine.theme.menuTipTextScale
         self.tipDir = 0
@@ -454,7 +454,7 @@ class Menu(Layer, KeyListener):
             self.tipDir = 0
         else:
             self.tipScroll = .5 - tipW / 2
-            self.tipScrollB = None
+            self.tipScrollB = 0
             self.tipTimerEnabled = False
             self.tipDir = 0
             self.tipSize = tipW

--- a/fofix/game/guitarscene/instruments/Guitar.py
+++ b/fofix/game/guitarscene/instruments/Guitar.py
@@ -358,7 +358,7 @@ class Guitar(Instrument):
             chords[time].append((time, note))
 
         # Make sure the notes are in the right time order
-        chordlist = chords.values()
+        chordlist = list(chords.values())
         chordlist.sort(key=lambda a: a[0][0])
 
         self.missedNotes = []

--- a/fofix/game/song/song.py
+++ b/fofix/game/song/song.py
@@ -1205,7 +1205,7 @@ class VocalPhrase(VocalTrack, Event):
         for _time, event in self.allEvents:
             if isinstance(event, VocalNote):
                 eventDict[int(_time)] = (_time, event)
-        times = eventDict.keys()
+        times = list(eventDict.keys())
         times.sort()
         for _time in times:
             newEvents.append(eventDict[_time])


### PR DESCRIPTION
* In python 3, `values()` and `keys()` do not return lists anymore, so results should be converted to list to sort them later
* Int values should be initialized with an int value.

Ref #110