### PR TITLE
fix: 'StreamingOggSound' is not defined

### DIFF
--- a/src/Audio.py
+++ b/src/Audio.py
@@ -425,15 +425,13 @@ class StreamingSound(Sound, Task):
 
   def __new__(cls, engine, channel, fileName):
     frequency, format, stereo = pygame.mixer.get_init()
-    if fileName.lower().endswith(".ogg"):
-      
+    if fileName.lower().endswith(".ogg") and ogg:
       return StreamingOggSound(engine, channel, fileName)   #MFH - forced allow of non-matching sample rates
-
 #-      if frequency == 44100 and format == -16 and stereo:
 #-        return StreamingOggSound(engine, channel, fileName)
 #-      else:
 #-        Log.warn("Audio settings must match stereo 16 bits at 44100 Hz in order to stream OGG files.")
-#-    return super(StreamingSound, cls).__new__(cls, engine, channel, fileName)
+    return super(StreamingSound, cls).__new__(cls, engine, channel, fileName)
 
   def play(self):
     self.channel.play(self)


### PR DESCRIPTION
If PyOGG is not available, the StreamingOggSound class will not have been defined when constructing a new StreamingSound for an .ogg file.

This can result in logs similar to:
(W) Unable to load guitar track: global name 'StreamingOggSound' is not defined