### PR TITLE
fix: AttributeError: type object 'Sound' has no attribute 'get_num_channels'

### DIFF
--- a/src/Audio.py
+++ b/src/Audio.py
@@ -445,7 +445,7 @@ class StreamingSound(Sound, Task):
     self.channel.setVolume(volume)
 
   def streamIsPlaying(self):  #MFH - adding function to check if sound is playing
-    return Sound.get_num_channels()
+    return Sound.isPlaying()
 
 
   def fadeout(self, time):


### PR DESCRIPTION
StreamingSound.streamIsPlaying() is currently implemented by returning Sound.get_num_channels(). This will result in an error since the Sound class has no method get_num_channels(). It does have a method isPlaying() which calls get_num_channels() on its self.sound object. Use this method instead.